### PR TITLE
Center panel

### DIFF
--- a/src/gui/Driver.java
+++ b/src/gui/Driver.java
@@ -99,7 +99,7 @@ public final class Driver extends JFrame
 			activateWindowListener();
 		mOtherPanel = panel;
 		pack();
-		centerComponent();
+		centerFrame();
 	}
 
 	public void revertToMainPanel()
@@ -109,7 +109,7 @@ public final class Driver extends JFrame
 		add(mMainPanel);
 		deactivateWindowListener();
 		pack();
-		centerComponent();
+		centerFrame();
 	}
 
 	public void setMenu(JMenu menu)
@@ -697,7 +697,7 @@ public final class Driver extends JFrame
 		return variantButton;
 	}
 
-	public static void centerComponent() {
+	public static void centerFrame() {
 		Driver driver = getInstance();
 		int width = driver.getWidth();
 		int height = driver.getHeight();

--- a/src/gui/NewGamePanel.java
+++ b/src/gui/NewGamePanel.java
@@ -132,7 +132,7 @@ public class NewGamePanel extends JPanel
 		mPopupFrame.setLayout(new GridBagLayout());
 		mPopupFrame.setSize(325, 225);
 		mPopupFrame.setResizable(false);
-		Driver.centerComponent();
+		Driver.centerFrame();
 		mPopupFrame.setLocationRelativeTo(Driver.getInstance());
 		mPopupFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
 		mPopupFrame.addWindowListener(new WindowAdapter()


### PR DESCRIPTION
It's possible I missed a few random cases, but the majority of cases work. Calling Driver.centerFrame() before any setLocationRelativeTo()s should take care of any lingering dissidents.
